### PR TITLE
Update the kacanopen submodule and move it to TrickfireRobotics's account.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,6 +12,3 @@
 	path = src/openzenros
 	url = https://bitbucket.org/lpresearch/openzenros.git
 	branch = yolo_hall
-[submodule "src/kacanopen"]
-	path = src/kacanopen
-	url = https://github.com/TrickfireRobotics/kacanopen

--- a/.gitmodules
+++ b/.gitmodules
@@ -12,3 +12,6 @@
 	path = src/openzenros
 	url = https://bitbucket.org/lpresearch/openzenros.git
 	branch = yolo_hall
+[submodule "src/kacanopen"]
+	path = src/kacanopen
+	url = https://github.com/TrickfireRobotics/kacanopen


### PR DESCRIPTION
The kacanopen submodule now points to https://github.com/TrickfireRobotics/kacanopen instead of https://github.com/dghani/kacanopen.

The submodule has also been updated so that *fingers crossed* it will stop printing "node X already found" messages to the console each time a heartbeart comes in from another CAN bus device. 